### PR TITLE
hide actions for incidents by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "load-grunt-tasks": "~3.2.0"
   },
   "dependencies": {
-     "lodash": ">=4.17.13"
+    "lodash": ">=4.17.13"
   },
   "homepage": "https://bosun.org"
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "load-grunt-tasks": "~3.2.0"
   },
   "dependencies": {
-    "lodash": "~4.0.0"
+     "lodash": ">=4.17.13"
   },
   "homepage": "https://bosun.org"
 }

--- a/src/panels/incident-list/editor.html
+++ b/src/panels/incident-list/editor.html
@@ -38,6 +38,12 @@
             </label>
 
             <editor-checkbox model="ctrl.panel.showActions" text=""></editor-checkbox>
+            <label class="gf-form-label">
+                Show Last Abnormal Timing:
+                <info-popover>Show details about the last abnormal status (state and time) for the incident</info-popover>
+            </label>
+
+            <editor-checkbox model="ctrl.panel.showAbnormalTime" text=""></editor-checkbox>
         </div>
     </div>
 </editor-row>

--- a/src/panels/incident-list/editor.html
+++ b/src/panels/incident-list/editor.html
@@ -32,6 +32,12 @@
             </label>
 
             <editor-checkbox model="ctrl.panel.showMulti" text=""></editor-checkbox>
+            <label class="gf-form-label">
+                Show Actions:
+                <info-popover>Show actions (add note, acknowledge, close, forget) for the alert</info-popover>
+            </label>
+
+            <editor-checkbox model="ctrl.panel.showActions" text=""></editor-checkbox>
         </div>
     </div>
 </editor-row>

--- a/src/panels/incident-list/module.html
+++ b/src/panels/incident-list/module.html
@@ -23,8 +23,8 @@
                 <tr>
                     <th ng-click="ctrl.sortIncidents('Subject')">Subject of Last Abnormal Status (if not unknown)</th>
                     <th ng-click="ctrl.sortIncidentsByStatus('CurrentStatus')">Current</th>
-                    <th ng-click="ctrl.sortIncidentsByStatus('LastAbnormalStatus')">Last Abnormal</th>
-                    <th ng-click="ctrl.sortIncidents('LastAbnormalTime')">Last Abnormal Time</th>
+                    <th ng-if="ctrl.panel.showAbnormalTime" ng-click="ctrl.sortIncidentsByStatus('LastAbnormalStatus')">Last Abnormal</th>
+                    <th ng-if="ctrl.panel.showAbnormalTime" ng-click="ctrl.sortIncidents('LastAbnormalTime')">Last Abnormal Time</th>
                     <th ng-click="ctrl.sortIncidentsByStatus('WorstStatus')">Worst</th>
                     <th>Show Details</th>
                     <th ng-if="ctrl.panel.showActions">Actions</th>
@@ -44,8 +44,8 @@
 
                     </td>
                     <td ng-bind="i.CurrentStatus" ng-class="ctrl.statusClass('text-', i.CurrentStatus)"></td>
-                    <td ng-bind="i.LastAbnormalStatus" ng-class="ctrl.statusClass('text-', i.LastAbnormalStatus)"></td>
-                    <td ng-bind="ctrl.fmtTime(i.LastAbnormalTime, true)" ng-class="ctrl.statusClass('text-', i.LastAbnormalStatus)"></td>
+                    <td ng-if="ctrl.panel.showAbnormalTime" ng-bind="i.LastAbnormalStatus" ng-class="ctrl.statusClass('text-', i.LastAbnormalStatus)"></td>
+                    <td ng-if="ctrl.panel.showAbnormalTime" ng-bind="ctrl.fmtTime(i.LastAbnormalTime, true)" ng-class="ctrl.statusClass('text-', i.LastAbnormalStatus)"></td>
                     <td ng-bind="i.WorstStatus" ng-class="ctrl.statusClass('text-', i.WorstStatus)"></td>
                     <td>
                         <a class="btn btn-inverse btn-small" ng-click="ctrl.showActions(i)">Actions</a>

--- a/src/panels/incident-list/module.html
+++ b/src/panels/incident-list/module.html
@@ -26,8 +26,8 @@
                     <th ng-click="ctrl.sortIncidentsByStatus('LastAbnormalStatus')">Last Abnormal</th>
                     <th ng-click="ctrl.sortIncidents('LastAbnormalTime')">Last Abnormal Time</th>
                     <th ng-click="ctrl.sortIncidentsByStatus('WorstStatus')">Worst</th>
-                    <th>Actions</th>
                     <th>Show Details</th>
+                    <th ng-if="ctrl.panel.showActions">Actions</th>
                     <th ng-if="ctrl.panel.showMulti || ctrl.fullscreen">Action</th>
                 </tr>
             </thead>
@@ -48,17 +48,17 @@
                     <td ng-bind="ctrl.fmtTime(i.LastAbnormalTime, true)" ng-class="ctrl.statusClass('text-', i.LastAbnormalStatus)"></td>
                     <td ng-bind="i.WorstStatus" ng-class="ctrl.statusClass('text-', i.WorstStatus)"></td>
                     <td>
+                        <a class="btn btn-inverse btn-small" ng-click="ctrl.showActions(i)">Actions</a>
+                        <a class="btn btn-inverse btn-small" ng-click="ctrl.showBody(i)">Body</a>
+                        <a class="btn btn-inverse btn-small" ng-click="ctrl.showEvents(i)">Events</a>
+                    </td>
+                    <td ng-if="ctrl.panel.showActions">
                         <a ng-if="ctrl.preRelease" class="btn btn-inverse btn-small" ng-click="ctrl.showActionForm(i, 'note')" target="_blank">Add Note </a>
                         <a ng-class="{'disabled': !i.NeedAck}" class="btn btn-inverse btn-small" ng-click="i.NeedAck && ctrl.showActionForm(i, 'ack')" target="_blank">Ack </a>
                         <a ng-class="{'disabled': i.CurrentStatus != 'normal'}" class="btn btn-inverse btn-small" ng-click="i.CurrentStatus == 'normal' && ctrl.showActionForm(i, 'close')"
                             target="_blank">Close </a>
                         <a ng-class="{'disabled': i.CurrentStatus != 'unknown'}" class="btn btn-inverse btn-small" ng-click="i.CurrentStatus == 'unknown' && ctrl.showActionForm(i, 'forget')"
                             target="_blank">Forget </a>
-                    </td>
-                    <td>
-                        <a class="btn btn-inverse btn-small" ng-click="ctrl.showActions(i)">Actions</a>
-                        <a class="btn btn-inverse btn-small" ng-click="ctrl.showBody(i)">Body</a>
-                        <a class="btn btn-inverse btn-small" ng-click="ctrl.showEvents(i)">Events</a>
                     </td>
                     <td ng-if="ctrl.panel.showMulti || ctrl.fullscreen">
                         <editor-checkbox model="i.selected" text="" ng-click="ctrl.selectRange($event, idx)"></editor-checkbox>

--- a/src/panels/incident-list/module.js
+++ b/src/panels/incident-list/module.js
@@ -34,6 +34,7 @@ export class BosunIncidentListCtrl extends MetricsPanelCtrl {
         this.datasourceSrv.get(this.panel.datasource).then(datasource => {
             this.preRelease = datasource.preRelease;
         });
+        this.events.on('init-edit-mode', this.onInitMetricsPanelEditMode.bind(this));
     }
 
     onInitMetricsPanelEditMode() {
@@ -187,7 +188,7 @@ export class BosunIncidentListCtrl extends MetricsPanelCtrl {
         this.showActionForm(incidents, this.selectedMultiAction)
     }
 
-    // incidents can be an incident, but also an [] of incidents    
+    // incidents can be an incident, but also an [] of incidents
     showActionForm(incidents, action) {
         if (!Array.isArray(incidents)) {
             incidents = [incidents]


### PR DESCRIPTION
This allows for a slightly cleaner look when using this panel in a NOC or with RO access to Bosun.