### PR TITLE
Fix incident panel overflow

### DIFF
--- a/src/panels/incident-list/module.html
+++ b/src/panels/incident-list/module.html
@@ -3,8 +3,8 @@
         vertical-align: top;
     }
 </style>
-<div>
-    <div ng-style="{'overflow-y': 'auto', 'max-height': ctrl.row.height}">
+<div style="height: 100%">
+    <div style="overflow-y: auto; height: 100%">
         <div class="pull-right">
             <div class="gf-form" ng-if="ctrl.panel.showMulti || ctrl.fullscreen">
                 <select class="input-small width-8" style="height: 24px" ng-model="ctrl.selectedMultiAction">


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

# Description

This pull request change style if the two first HTML `div` element in the incident list panel make the height at `100%` for both `div` so they're content aren't displayed outside the panel.

Fixes #40

## Type of change

From the following, please check the options that are relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?

Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Please also list any relevant details for your test configuration

- [X] Tested with grafana 7.3.0 and 7.5.5. I created around ten alerts in Bosun and try to displayed them in the alert panel.

# Checklist:

- [X] This contribution follows the project's [code of conduct](https://github.com/bosun-monitor/bosun-grafana-app/blob/master/CODE_OF_CONDUCT.md)
- [X] This contribution follows the project's [contributing guidelines](https://github.com/bosun-monitor/bosun-grafana-app/blob/master/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

