### PR TITLE
Fix panel configuration options

### DIFF
--- a/src/panels/incident-list/module.js
+++ b/src/panels/incident-list/module.js
@@ -34,6 +34,7 @@ export class BosunIncidentListCtrl extends MetricsPanelCtrl {
         this.datasourceSrv.get(this.panel.datasource).then(datasource => {
             this.preRelease = datasource.preRelease;
         });
+        this.events.on('init-edit-mode', this.onInitMetricsPanelEditMode.bind(this));
     }
 
     onInitMetricsPanelEditMode() {


### PR DESCRIPTION
# Description

This pull request fix the panel options not showing up. As stated in the #29 issue, binding `init-edit-mode` event fix the problem. 

Fixes #29  (fill in)

## Type of change

From the following, please check the options that are relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?

Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Please also list any relevant details for your test configuration

- [X] Check manually that panel options now shows up in grafana 7.3.0 and 7.5.5

# Checklist:

- [X] This contribution follows the project's [code of conduct](https://github.com/bosun-monitor/bosun-grafana-app/blob/master/CODE_OF_CONDUCT.md)
- [X] This contribution follows the project's [contributing guidelines](https://github.com/bosun-monitor/bosun-grafana-app/blob/master/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

